### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ BottomSheetBehavior的定义如下
 
 目前为止，我们只是了解了CoordinatorLayout.Behavior相关的东西，还是不知道BottomSheetBehavior实现的原理，别急，这就和你说说。
 
-###view布局
+### view布局
 当你的View持有Behavior的时候,
 CoordinatorLayout 在 onLayout 的时候会调用`Behavior.onLayoutChild`方法进行布局.
 
-####注意:我们将持有的Behavior 的View 叫做BehaviorView
+#### 注意:我们将持有的Behavior 的View 叫做BehaviorView
 
 我们查看onLayoutChild 的源码
 ```java
@@ -154,8 +154,8 @@ PeekHeight为0的时候 整个BehaviorView 被移到屏幕外, 它就不会被�
 我的好基友dim给出了解决方案[Android support 23.2 使用BottomSheetBehavior 的坑](http://www.jianshu.com/p/21bb14e3be94)
 
 
-###事件拦截
-####touch 事件会先被onInterceptTouchEvent()捕获,进行判断是否拦截.
+### 事件拦截
+#### touch 事件会先被onInterceptTouchEvent()捕获,进行判断是否拦截.
 
 ```java
 
@@ -209,7 +209,7 @@ public boolean onInterceptTouchEvent(CoordinatorLayout parent, V child, MotionEv
             Math.abs(mInitialY - event.getY()) > mViewDragHelper.getTouchSlop();
 }
 ```
-####onInterceptTouchEvent 做了几件事情:
+#### onInterceptTouchEvent 做了几件事情:
 
 1. 判断是否拦截事件.先使用mViewDragHelper.shouldInterceptTouchEvent(event)拦截.
 
@@ -219,7 +219,7 @@ public boolean onInterceptTouchEvent(CoordinatorLayout parent, V child, MotionEv
 
 4. ACTION_UP 和ACTION_CANCEL 对标记位进行复位,好在下一轮 Touch 事件中使用.
 
-####onTouchEvent处理
+#### onTouchEvent处理
 ```java
 
  @Override
@@ -250,7 +250,7 @@ public boolean onInterceptTouchEvent(CoordinatorLayout parent, V child, MotionEv
         return true;
     }
 ```
-####onTouchEvent 主要做了几件事情:
+#### onTouchEvent 主要做了几件事情:
 
 1. 使用mVelocityTracker 记录手指动作.用于后期计算Y 轴速率.
 
@@ -258,7 +258,7 @@ public boolean onInterceptTouchEvent(CoordinatorLayout parent, V child, MotionEv
 
 3. mViewDragHelper 在滑动的时候对BehaviorView 的再一次捕获.再一次明确告诉ViewDragHelper 我要移动的是BehaviorView 组件.什么情况需要主动告诉ViewDragHelper ?比如:当你点击在BehaviorView 的区域,但是BehaviorView 的视图的层级不是最高的,或者你点击的区域不在 BehaviorView 上,ViewDragHelper 在做处理滑动的时候找不到BehaviorView, 这个时候你要手动告知它现在要移动的是BehaviorView,情景类似ViewDragHelper处理EdgeDrag 的样子.
 
-####注意
+#### 注意
 即使你的onInterceptTouchEvent 返回false,也可能因为下面的View 没有处理这个Touch事件,而导致Touch 事件上发被Behavior的onTouchEvent 被截取.
 
 ### NestedScrolling事件处理
@@ -273,7 +273,7 @@ public boolean onInterceptTouchEvent(CoordinatorLayout parent, V child, MotionEv
 返回值 true :表示 BehaviorView 要和NestedScrollingChild 配合消耗这个 NestedScrolling 事件,这里可以看出只要是纵向的滑动都会返回true.
 
 
-####onNestedPreScroll
+#### onNestedPreScroll
 NestedScrollingChild的在滑动的时候会触发`onNestedPreScroll` 方法,询问BehaviorView消耗多少Y轴上面的滑动.
 ```java
   @Override
@@ -314,7 +314,7 @@ NestedScrollingChild的在滑动的时候会触发`onNestedPreScroll` 方法,询
     }
 
 ```
-####onNestedPreScroll 方法主要做几件事情:
+#### onNestedPreScroll 方法主要做几件事情:
 
 1. 判断发起NestedScrolling 的 View 是否是我们在onLayoutChild 找到的那个控件.不是的话,不做处理.不处理就是不消耗y 轴,把所有的Scroll 交给发起的 View 自己消耗.
 
@@ -327,11 +327,11 @@ NestedScrollingChild的在滑动的时候会触发`onNestedPreScroll` 方法,询
 `onStopNestedScroll`在Nestd事件结束触发.
 主要做的事情:
 根据BehaviorView当前的状态对它的最终位置的确定,有必要的话调用`ViewDragHelper.smoothSlideViewTo` 进行滑动.
-####注意
+#### 注意
 当你是往下滑动且Hideable 为 true ,他会
 使用上面计算的Y轴的速率的判断.是否应该切换到Hideable 的状态.
 
-####onNestedPreFling
+#### onNestedPreFling
 这个是 NestedScrollingChild 要滑行时候触发的,询问 BehaviorView是否消耗这个滑行.
 ```
 
@@ -348,11 +348,11 @@ public boolean onNestedPreFling(CoordinatorLayout coordinatorLayout, V child, Vi
 
 返回值: true表示BehaviorView 消耗滑行事件,那么NestedScrollingChild就不会有滑行了
 
-####ViewDragHelper.Callback
+#### ViewDragHelper.Callback
 ViewDragHelper网上教程挺多的,就不多讲了,他主要是处理滑动拖拽的.
 
 
-####小技巧
+#### 小技巧
 在说说一个小技巧，Android官网中有这样一句话：[Enums often require more than twice as much memory as static constants. You should strictly avoid using enums on Android](http://developer.android.com/intl/zh-cn/training/articles/memory.html),就是说枚举比静态常量更加耗费内存，我们应该避免使用，然后我看BottomSheetBehavior源码中 mState 是这样定义的：
 ```java
     public static final int STATE_DRAGGING = 1;
@@ -372,12 +372,12 @@ ViewDragHelper网上教程挺多的,就不多讲了,他主要是处理滑动拖�
 弥补了Android不建议使用枚举的缺陷。
 
 
-###Have a nice weekend ! Bye bye.
+### Have a nice weekend ! Bye bye.
 
 转载请注明出处，不然我咬你哦！
 
 
-###Thanks: dim   
+### Thanks: dim   
 [微博](http://weibo.com/u/5579192921?from=myfollow_all&is_all=1) 
 
 [github](https://github.com/zzz40500)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
